### PR TITLE
Prefer glue_data() when data might be list-ish, not an actual environment

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^docs$
 ^pkgdown$
 ^\.github$
+cran-comments.md

--- a/R/convert_re.R
+++ b/R/convert_re.R
@@ -58,7 +58,7 @@ build_format_regex <- function(
     format_re
   } else if (!missing(format) && !is.null(format)) {
     format <- escape_non_glue_re(format)
-    glue::glue(format, .envir = as.list(keywords))
+    glue::glue_data(as.list(keywords), format)
   } else {
     "(?<description>.*)"
   }


### PR DESCRIPTION
This PR is inspired by doing revdep checks for glue. In the next release of glue, which is _very soon_, `glue::glue()` will error when `.envir` is not an actual environment. `.envir` has always been documented to be an environment and I've been working to make this actually true.

I last did revdep checks for this in December 2023 and I opened issue or PRs everywhere that I could. So roxytypes's usage of this pattern must have arisen more recently (?).

`glue_data()` *does* officially accept something "list-ish" as `.x`. So you should switch to `glue_data(.x = list_ish_thing, ...)` as opposed to `glue(.envir = list_ish_thing, ...)`.

Relevant links in glue:

https://github.com/tidyverse/glue/issues/308
https://github.com/tidyverse/glue/commit/e2b74ff17704261b5a7da25b4ebd2dec94740764
https://github.com/tidyverse/glue/issues/341

Here's what I'm currently seeing for roxytypes in glue's revdep checks:
https://github.com/tidyverse/glue/blob/main/revdep/problems.md#roxytypes